### PR TITLE
Allow for empty wifi password

### DIFF
--- a/src/ios/BlinkUpPlugin.m
+++ b/src/ios/BlinkUpPlugin.m
@@ -373,7 +373,7 @@ typedef NS_ENUM(NSInteger, WPSBlinkUpArguments) {
  ********************************************************/
 - (BOOL) sendWifiErrorToCallbackIfArgumentsInvalid {
 
-    BOOL invalidArguments = self.timeoutMs == 0 || [self.ssid length] == 0 || [self.password length] == 0;
+    BOOL invalidArguments = self.timeoutMs == 0 || [self.ssid length] == 0;
     BOOL invalidApiKey = ![BlinkUpPlugin isApiKeyFormatValid:self.apiKey];
 
     // send error to callback


### PR DESCRIPTION
Currently, this plugin doesn't allow using empty wifi password.
This PR is intended to fix this issue but the code change hasn't been tested in any way.